### PR TITLE
Added option to disabled timestamp generation

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -18,7 +18,8 @@ const RXS = {
 const DOPS = {
 	cef : true,
 	fields : true,
-	pid : true
+	pid : true,
+	generateTimestamp: true
 }
 
 function peek(arr) {
@@ -100,7 +101,7 @@ function parse(line,opts) {
 	}
 
 	// No timestamp
-	if(!entry.ts) entry.ts = new Date();
+	if(!entry.ts && opts.generateTimestamp) entry.ts = new Date();
 
 	// Is a standard syslog message
 	if(entry.type) {


### PR DESCRIPTION
This is a really useful feature for us, as we want to fallback on the time the message was received in our system if there is none specified by the syslog. The parser automatically generates a timestamp if that's the case.

It would be great to have an option to leave the timestamp as `undefined`!